### PR TITLE
Change placeholders with actual data

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 **Colorize your images with diverse palettes in a macOS-inspired interface.**
 
-![WallRice Preview](./docs/screenshot.png)
-_Screenshot placeholder - Add your screenshot here_
+![WallRice Preview](/public/preview.png)
 
 ---
 
@@ -30,7 +29,7 @@ _Screenshot placeholder - Add your screenshot here_
 1.  **Clone the repository**
 
     ```bash
-    git clone https://github.com/yourusername/wallrice.git
+    git clone git@github.com:groovykiwi/wallrice.git
     cd wallrice
     ```
 


### PR DESCRIPTION
This pull request updates the `README.md` file to improve clarity and provide accurate information for users. The changes include replacing a placeholder screenshot with a proper preview image and updating the repository URL in the cloning instructions.

Improvements to documentation:

* Updated the screenshot reference to use an actual preview image located at `/public/preview.png`, replacing the placeholder text.
* Updated the repository cloning instructions to use the correct SSH URL (`git@github.com:groovykiwi/wallrice.git`) instead of a placeholder HTTPS URL. 